### PR TITLE
Add global .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json


### PR DESCRIPTION
Adding a global .gitignore to root so we can exclude the root package-lock.json.